### PR TITLE
fix breach notifications

### DIFF
--- a/desk/app/emissary.hoon
+++ b/desk/app/emissary.hoon
@@ -210,9 +210,10 @@
       that
     ::  someone breached
     =/  =ship  who.public-keys-result.sign-arvo
-    ?:  ?&  (~(has in patrons) ship)
+    ?.  ?|  (~(has in patrons) ship)
             (~(has by delegates) ship)
             (~(has in requests) ship)
+            (~(has by queries) ship)
         ==
       that
     =.  that  (poke %emissary-trigger !>(`trigger`[%revoke ship]))
@@ -222,7 +223,7 @@
     %-  emil
     ^-  (list card)
     ?.  .^(? %gu /(scot %p our.bol)/hark/(scot %da now.bol)/$)  ~
-    =/  con=(list content:hark)  [[%ship ship] 'Breach notification received; removed from %emissary.' ~]
+    =/  con=(list content:hark)  [[%ship ship] ' breached; removed from %emissary.' ~]
     =/  =id:hark      (end 7 (shas %emissary-trigger eny.bol))
     =/  =rope:hark    [~ ~ q.byk.bol /(scot %p ship)/[dap.bol]]
     =/  =action:hark  [%add-yarn & & id rope now.bol con /[dap.bol] ~]

--- a/desk/desk.docket-0
+++ b/desk/desk.docket-0
@@ -3,7 +3,7 @@
     color+0x64.5050
     image+'https://raw.githubusercontent.com/sigilante/emissary/master/img/emissary-icon.png'
     site+/apps/emissary
-    version+[1 4 2]
+    version+[1 4 3]
     website+'https://urbit.org'
     license+'MIT'
 ==


### PR DESCRIPTION
currently it hark-notifies me for every breach notif I receive, not just the ships I actually have in emissary. This fixes that and also adds a space between the ship and the text in the notification.